### PR TITLE
Update CmakeLists for colcon build

### DIFF
--- a/spot_description/CMakeLists.txt
+++ b/spot_description/CMakeLists.txt
@@ -8,3 +8,7 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+install(DIRECTORY launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)


### PR DESCRIPTION
@grassjelly, Now, it is possible to launch all files when coclon build was used. 